### PR TITLE
manifest: add run deps on plugin tools

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>catkin_virtualenv</build_depend>
+
+  <run_depend>cccc</run_depend>
   <run_depend>cppcheck</run_depend>
+  <run_depend>libclang-dev</run_depend>
 
   <export>
     <pip_requirements>requirements.txt</pip_requirements>

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
 
   <run_depend>cccc</run_depend>
   <run_depend>cppcheck</run_depend>
-  <run_depend>libclang-dev</run_depend>
 
   <export>
     <pip_requirements>requirements.txt</pip_requirements>


### PR DESCRIPTION
As per subject.

 - `cccc` was added in ros/rosdistro#20426
 - `libclang-dev` will be added in ros/rosdistro#20461
