### PR TITLE
Revert "Changed command to execute haros"

### DIFF
--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -3,6 +3,13 @@ if (_HAROS_EXTRAS_INCLUDED_)
 endif()
 set(_HAROS_EXTRAS_INCLUDED_ TRUE)
 
+
+@[if DEVELSPACE]@
+  set(@(PROJECT_NAME)_VENV_BIN_DIR @(CATKIN_DEVEL_PREFIX)/@(CATKIN_PACKAGE_SHARE_DESTINATION)/venv/bin)
+@[else]@
+  set(@(PROJECT_NAME)_VENV_BIN_DIR @(CMAKE_INSTALL_PREFIX)/@(CATKIN_PACKAGE_SHARE_DESTINATION)/venv/bin)
+@[end if]@
+
 macro(_haros_create_targets)
   if (NOT TARGET haros_report)
     add_custom_target(haros_report)
@@ -16,9 +23,10 @@ endmacro()
 
 function(haros_report)
   set(HAROS_REPORT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/test_results/haros_report")
+  set(HAROS_COMMAND "${@(PROJECT_NAME)_VENV_BIN_DIR}/python" "${@(PROJECT_NAME)_VENV_BIN_DIR}/haros")
   _haros_create_targets()
   add_custom_command(TARGET haros_report_${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}
-        COMMAND rosrun haros_catkin haros init
-        COMMAND rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION})
+        COMMAND ${HAROS_COMMAND} init
+        COMMAND ${HAROS_COMMAND} -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION})
 endfunction()

--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -23,7 +23,7 @@ endmacro()
 
 function(haros_report)
   set(HAROS_REPORT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/test_results/haros_report")
-  set(HAROS_COMMAND "${@(PROJECT_NAME)_VENV_BIN_DIR}/python" "${@(PROJECT_NAME)_VENV_BIN_DIR}/haros")
+  set(HAROS_COMMAND "${@(PROJECT_NAME)_VENV_BIN_DIR}/haros")
   _haros_create_targets()
   add_custom_command(TARGET haros_report_${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}


### PR DESCRIPTION
This PR reverts the change to execute `haros` in the `haros_catkin` package because the Docker environment used by the ROS buildfarm does not allow calling rosrun commands directly.