### PR TITLE
Set haros_report to be executed on ALL

### DIFF
--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -5,7 +5,7 @@ set(_HAROS_EXTRAS_INCLUDED_ TRUE)
 
 macro(_haros_create_targets)
   if (NOT TARGET haros_report)
-    add_custom_target(haros_report)
+    add_custom_target(haros_report ALL)
   endif()
 
   if (NOT TARGET haros_report_${PROJECT_NAME})


### PR DESCRIPTION
We need to execute the `haros_report` macro as a plain test in order to allow its usage within the ROS buildfarm without modifying the appropriate buildfarm scripts.