### PR TITLE
Require version of HAROS that supports pip-installed plugins.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-haros>=2.1.2
+haros>=3.3.0
 pyflwor-ext==1.2


### PR DESCRIPTION
Progress in #10.