### PR TITLE
Use catkin env script so rosrun et al. can be used

### DIFF
--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -19,6 +19,7 @@ function(haros_report)
   _haros_create_targets()
   add_custom_command(TARGET haros_report_${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}
-        COMMAND rosrun haros_catkin haros init
-        COMMAND rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION})
+        COMMAND ${CATKIN_ENV} rosrun haros_catkin haros init
+        COMMAND ${CATKIN_ENV} rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION}
+  )
 endfunction()

--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -18,6 +18,7 @@ function(haros_report)
   set(HAROS_REPORT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/test_results/haros_report")
   _haros_create_targets()
   add_custom_command(TARGET haros_report_${PROJECT_NAME} POST_BUILD
+        COMMAND echo "Executing Haros for '${PROJECT_SOURCE_DIR}' .."
         COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}
         COMMAND ${CATKIN_ENV} rosrun haros_catkin haros init
         COMMAND ${CATKIN_ENV} rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION}

--- a/cmake/haros_catkin-extras.cmake.em
+++ b/cmake/haros_catkin-extras.cmake.em
@@ -18,9 +18,9 @@ function(haros_report)
   set(HAROS_REPORT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/test_results/haros_report")
   _haros_create_targets()
   add_custom_command(TARGET haros_report_${PROJECT_NAME} POST_BUILD
-        COMMAND echo "Executing Haros for '${PROJECT_SOURCE_DIR}' .."
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}
-        COMMAND ${CATKIN_ENV} rosrun haros_catkin haros init
-        COMMAND ${CATKIN_ENV} rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION}
+    COMMAND echo "Executing Haros for '${PROJECT_SOURCE_DIR}' .."
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${HAROS_REPORT_LOCATION}
+    COMMAND ${CATKIN_ENV} rosrun haros_catkin haros init
+    COMMAND ${CATKIN_ENV} rosrun haros_catkin haros -c ${PROJECT_SOURCE_DIR} analyse -d ${HAROS_REPORT_LOCATION}
   )
 endfunction()


### PR DESCRIPTION
This makes use of the `CATKIN_ENV` variable which contains the full path to the `env.sh` script that sets up a ROS environment for the current workspace (or global ROS installation).

This avoids having to `source` a `setup.bash` ourselves and allows us to use `rosrun` and `rospack` from within the CMake `haros_report()` function without having to manually derive any locations of scripts or the `venv`.
