### PR TITLE
Add run dependency on rosgraph

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>cccc</run_depend>
   <run_depend>cppcheck</run_depend>
+  <run_depend>rosgraph</run_depend>
 
   <export>
     <pip_requirements>requirements.txt</pip_requirements>


### PR DESCRIPTION
As per subject.

Without this use of `haros_catkin` in a prerelease Docker environment (which supposedly is similar to the ROS buildfarm) will end in a failure to import the `rosgraph` Python module.

I'm not entirely sure I like this dependency here, but it makes things work, so until we have a better alternative this is acceptable.
