### PR TITLE
Add industrial_ci travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - AFTER_SCRIPT='./test_haros_report.sh' # execute haros_report on haros_catkin_test after the build
   matrix: # each line is a job
-    - ROS_DISTRO="lunar"    ROS_REPO=ros-shadow-fixed DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master" # overrides the global
+    - ROS_DISTRO="lunar"    ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE="github:locusrobotics/catkin_virtualenv#f823bc6" DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master" # overrides the global
     - ROS_DISTRO="kinetic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
     - ROS_DISTRO="melodic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - ROS_REPO=ros
     - CCACHE_DIR=$HOME/.ccache
-    - AFTER_SCRIPT='./test_haros_report.sh'
+    - AFTER_SCRIPT='catkin build --workspace=/root/downstream_ws test_pkg --verbose --no-deps --make-args haros_report'
   matrix:
     - ROS_DISTRO="kinetic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
     - ROS_DISTRO="melodic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,8 @@ env:
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - AFTER_SCRIPT='./test_haros_report.sh' # execute haros_report on haros_catkin_test after the build
   matrix: # each line is a job
-    - ROS_DISTRO="lunar"    ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE="github:locusrobotics/catkin_virtualenv#f823bc6" DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master" # overrides the global
     - ROS_DISTRO="kinetic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
     - ROS_DISTRO="melodic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
-
-# allow failures, e.g. for unsupported distros
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO="lunar" ROS_REPO=ros-shadow-fixed
 
 # clone and run industrial_ci
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,26 @@
-# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
-# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
-
-language: generic # optional, just removes the language badge
+language: generic
 
 services:
   - docker
 
-# include the following block if the C/C++ build artifacts should get cached by Travis,
-# CCACHE_DIR needs to get set as well to actually fill the cache
 cache:
   directories:
     - $HOME/.ccache
 
 git:
-  quiet: true # optional, silences the cloning of the target repository
+  quiet: true
 
-# configure the build environment(s)
-# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:
-  global: # global settings for all jobs
+  global:
     - ROS_REPO=ros
-    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
-    - AFTER_SCRIPT='./test_haros_report.sh' # execute haros_report on haros_catkin_test after the build
-  matrix: # each line is a job
+    - CCACHE_DIR=$HOME/.ccache
+    - AFTER_SCRIPT='./test_haros_report.sh'
+  matrix:
     - ROS_DISTRO="kinetic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
     - ROS_DISTRO="melodic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
 
-# clone and run industrial_ci
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+
 script:
   - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+language: generic # optional, just removes the language badge
+
+services:
+  - docker
+
+# include the following block if the C/C++ build artifacts should get cached by Travis,
+# CCACHE_DIR needs to get set as well to actually fill the cache
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true # optional, silences the cloning of the target repository
+
+# configure the build environment(s)
+# https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
+env:
+  global: # global settings for all jobs
+    - ROS_REPO=ros
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
+    - AFTER_SCRIPT='./test_haros_report.sh' # execute haros_report on haros_catkin_test after the build
+  matrix: # each line is a job
+    - ROS_DISTRO="lunar"    ROS_REPO=ros-shadow-fixed DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master" # overrides the global
+    - ROS_DISTRO="kinetic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
+    - ROS_DISTRO="melodic"  DOWNSTREAM_WORKSPACE="github:ipa-jfh/haros_catkin_test#master"
+
+# allow failures, e.g. for unsupported distros
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="lunar" ROS_REPO=ros-shadow-fixed
+
+# clone and run industrial_ci
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+script:
+  - .industrial_ci/travis.sh

--- a/test_haros_report.sh
+++ b/test_haros_report.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /root/downstream_ws
+catkin build test_pkg --verbose --no-deps --make-args haros_report

--- a/test_haros_report.sh
+++ b/test_haros_report.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd /root/downstream_ws
-catkin build test_pkg --verbose --no-deps --make-args haros_report


### PR DESCRIPTION
This adds a slightly modified `travis.yml` with its origin from [industrial_ci](https://github.com/ros-industrial/industrial_ci/blob/efaa18b9322717f562a832c61a4963613bb84188/.travis.yml).
Note that this is based on the `legacy` branch. If the current `master` is preferred I can update this of course.

The configuration adds [`haros_catkin_test`](https://github.com/ipa-jfh/haros_catkin_test) as a downstream package (see discussion in https://github.com/rosin-project/haros_catkin/issues/21) and executes a script invoking the required `make` target `haros_report`.

Should fix https://github.com/rosin-project/haros_catkin/issues/21.